### PR TITLE
Adds support for the `destroy-room` endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.0.4
+
+* Added support for the predefined command `destroy_room`
+
 ### 1.0.3
 
 * Migrated to Github Actions

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Here comes a list of all supported predefined commands:
 - [subscribe_room](https://bit.ly/2Ke7Zoy)
 - [unregister](https://bit.ly/2wwYnDE)
 - [unsubscribe_room](https://bit.ly/2G5zcrj)
+- [destroy_room](https://bit.ly/31CtqxB)
 
 If you want to contribute more, we accept pull requests!
 

--- a/lib/jabber_admin/commands/destroy_room.rb
+++ b/lib/jabber_admin/commands/destroy_room.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module JabberAdmin
+  module Commands
+    # Destroys a given room (MUC).
+    #
+    # @see https://bit.ly/31CtqxB
+    class DestroyRoom
+      # Pass the correct data to the given callable.
+      #
+      # @param callable [Proc, #call] the callable to call
+      # @param room [String] room JID (eg. +room1@conference.localhost+)
+      # @param host [String] the jabber host (eg. +localhost+)
+      def self.call(callable, room:, host:)
+        name, service = room.split('@')
+        callable.call('destroy_room', name: name, service: service, host: host)
+      end
+    end
+  end
+end

--- a/spec/fixtures/vcr_cassettes/JabberAdmin_Commands_DestroyRoom/behaves_like_a_command/integration_test/raises_no_errors.yml
+++ b/spec/fixtures/vcr_cassettes/JabberAdmin_Commands_DestroyRoom/behaves_like_a_command/integration_test/raises_no_errors.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://jabber/api/destroy_room
+    body:
+      encoding: UTF-8
+      string: '{"name":"room1","service":"conference.ejabberd.local","host":"ejabberd.local"}'
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.9p229
+      Content-Length:
+      - '78'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - jabber
+      Authorization:
+      - Basic YWRtaW5AZWphYmJlcmQubG9jYWw6ZGVmYXVsdHB3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '1'
+      Content-Type:
+      - application/json
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Content-Type, Authorization, X-Admin
+    body:
+      encoding: UTF-8
+      string: '0'
+  recorded_at: Wed, 10 Nov 2021 13:11:17 GMT
+recorded_with: VCR 6.0.0

--- a/spec/jabber_admin/commands/destroy_room_spec.rb
+++ b/spec/jabber_admin/commands/destroy_room_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe JabberAdmin::Commands::DestroyRoom do
+  it_behaves_like 'a command',
+                  with_name: 'destroy_room',
+                  with_input_args: [
+                    room: 'room1@conference.ejabberd.local',
+                    host: 'ejabberd.local'
+                  ],
+                  with_called_args: [
+                    name: 'room1',
+                    service: 'conference.ejabberd.local',
+                    host: 'ejabberd.local'
+                  ]
+end


### PR DESCRIPTION
We'd like to be able to delete old MUCs whose data is no longer needed. As such support for the [`destroy_room`](https://docs.ejabberd.im/developer/ejabberd-api/admin-api/#destroy-room) endpoint of ejabberd has been added