### PR TITLE
Add get_room_affiliations command

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Here comes a list of all supported predefined commands:
 - [unregister](https://bit.ly/2wwYnDE)
 - [unsubscribe_room](https://bit.ly/2G5zcrj)
 - [destroy_room](https://bit.ly/31CtqxB)
+- [get_room_affiliations](https://bit.ly/3qI9Nyq)
 
 If you want to contribute more, we accept pull requests!
 

--- a/lib/jabber_admin.rb
+++ b/lib/jabber_admin.rb
@@ -112,6 +112,21 @@ module JabberAdmin
     proc { |*args| ApiCall.send(method, *args) }
   end
 
+  # Determine if a room exists. This is a convenience method for the
+  # +JabberAdmin::Commands::GetRoomAffiliations+ command, which can be used
+  # to reliably determine whether a room exists or not.
+  #
+  # @param room [String] the name of the room to check
+  # @return [Boolean] whether the room exists or not
+  def self.room_exist?(room)
+    get_room_affiliations!(room: room)
+    true
+  rescue JabberAdmin::CommandError => e
+    raise e unless /room does not exist/.match? e.response.body
+
+    false
+  end
+
   # We support all methods if you ask for. This is our dynamic command approach
   # here to support predefined and custom commands in the same namespace.
   #

--- a/lib/jabber_admin/commands/get_room_affiliations.rb
+++ b/lib/jabber_admin/commands/get_room_affiliations.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module JabberAdmin
+  module Commands
+    # Get room affiliations.
+    #
+    # @see https://bit.ly/3qI9Nyq
+    class GetRoomAffiliations
+      # Pass the correct data to the given callable.
+      #
+      # @param callable [Proc, #call] the callable to call
+      # @param room [String] room JID (eg. +room1@conference.localhost+)
+      def self.call(callable, room:)
+        name, service = room.split('@')
+        res = callable.call('get_room_affiliations', check_res_body: false,
+                                                     name: name,
+                                                     service: service)
+
+        res.body ? JSON.parse(res.body) : nil
+      end
+    end
+  end
+end

--- a/spec/fixtures/vcr_cassettes/JabberAdmin/_room_exist_/with_an_existing_room/returns_true.yml
+++ b/spec/fixtures/vcr_cassettes/JabberAdmin/_room_exist_/with_an_existing_room/returns_true.yml
@@ -1,0 +1,75 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://jabber/api/create_room
+    body:
+      encoding: UTF-8
+      string: '{"name":"room1","service":"conference.ejabberd.local","host":"conference.ejabberd.local"}'
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.9p229
+      Content-Length:
+      - '89'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - jabber
+      Authorization:
+      - Basic YWRtaW5AZWphYmJlcmQubG9jYWw6ZGVmYXVsdHB3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '1'
+      Content-Type:
+      - application/json
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Content-Type, Authorization, X-Admin
+    body:
+      encoding: UTF-8
+      string: '0'
+  recorded_at: Thu, 20 Jan 2022 13:20:27 GMT
+- request:
+    method: post
+    uri: http://jabber/api/get_room_affiliations
+    body:
+      encoding: UTF-8
+      string: '{"name":"room1","service":"conference.ejabberd.local"}'
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.9p229
+      Content-Length:
+      - '54'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - jabber
+      Authorization:
+      - Basic YWRtaW5AZWphYmJlcmQubG9jYWw6ZGVmYXVsdHB3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Content-Type, Authorization, X-Admin
+    body:
+      encoding: UTF-8
+      string: '[{"username":"tom","domain":"localhost","affiliation":"member","reason":""}]'
+  recorded_at: Thu, 20 Jan 2022 13:20:27 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/JabberAdmin/_room_exist_/without_an_existing_room/returns_false.yml
+++ b/spec/fixtures/vcr_cassettes/JabberAdmin/_room_exist_/without_an_existing_room/returns_false.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://jabber/api/get_room_affiliations
+    body:
+      encoding: UTF-8
+      string: '{"name":"no-room","service":"conference.ejabberd.local"}'
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.9p229
+      Content-Length:
+      - '56'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - jabber
+      Authorization:
+      - Basic YWRtaW5AZWphYmJlcmQubG9jYWw6ZGVmYXVsdHB3
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Content-Length:
+      - '26'
+      Content-Type:
+      - application/json
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Content-Type, Authorization, X-Admin
+    body:
+      encoding: UTF-8
+      string: '"The room does not exist."'
+  recorded_at: Thu, 20 Jan 2022 13:20:27 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/JabberAdmin_Commands_GetRoomAffiliations/when_the_room_does_not_exist/raises_an_error.yml
+++ b/spec/fixtures/vcr_cassettes/JabberAdmin_Commands_GetRoomAffiliations/when_the_room_does_not_exist/raises_an_error.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://jabber/api/get_room_affiliations
+    body:
+      encoding: UTF-8
+      string: '{"name":"vroom","service":"conference.ejabberd.local"}'
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.9p229
+      Content-Length:
+      - '54'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - jabber
+      Authorization:
+      - Basic YWRtaW5AZWphYmJlcmQubG9jYWw6ZGVmYXVsdHB3
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Content-Length:
+      - '26'
+      Content-Type:
+      - application/json
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Content-Type, Authorization, X-Admin
+    body:
+      encoding: UTF-8
+      string: '"The room does not exist."'
+  recorded_at: Thu, 20 Jan 2022 13:20:27 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/JabberAdmin_Commands_GetRoomAffiliations/when_the_room_exists/with_affiliations/behaves_like_a_command/calls_the_call_method_on_the_given_callable.yml
+++ b/spec/fixtures/vcr_cassettes/JabberAdmin_Commands_GetRoomAffiliations/when_the_room_exists/with_affiliations/behaves_like_a_command/calls_the_call_method_on_the_given_callable.yml
@@ -1,0 +1,75 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://jabber/api/create_room
+    body:
+      encoding: UTF-8
+      string: '{"name":"room1","service":"conference.ejabberd.local","host":"conference.ejabberd.local"}'
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.9p229
+      Content-Length:
+      - '89'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - jabber
+      Authorization:
+      - Basic YWRtaW5AZWphYmJlcmQubG9jYWw6ZGVmYXVsdHB3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '1'
+      Content-Type:
+      - application/json
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Content-Type, Authorization, X-Admin
+    body:
+      encoding: UTF-8
+      string: '0'
+  recorded_at: Thu, 20 Jan 2022 13:20:27 GMT
+- request:
+    method: post
+    uri: http://jabber/api/set_room_affiliation
+    body:
+      encoding: UTF-8
+      string: '{"name":"room1","service":"conference.ejabberd.local","jid":"tom@localhost","affiliation":"member"}'
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.9p229
+      Content-Length:
+      - '99'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - jabber
+      Authorization:
+      - Basic YWRtaW5AZWphYmJlcmQubG9jYWw6ZGVmYXVsdHB3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '1'
+      Content-Type:
+      - application/json
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Content-Type, Authorization, X-Admin
+    body:
+      encoding: UTF-8
+      string: '0'
+  recorded_at: Thu, 20 Jan 2022 13:20:27 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/JabberAdmin_Commands_GetRoomAffiliations/when_the_room_exists/with_affiliations/behaves_like_a_command/integration_test/raises_no_errors.yml
+++ b/spec/fixtures/vcr_cassettes/JabberAdmin_Commands_GetRoomAffiliations/when_the_room_exists/with_affiliations/behaves_like_a_command/integration_test/raises_no_errors.yml
@@ -1,0 +1,111 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://jabber/api/create_room
+    body:
+      encoding: UTF-8
+      string: '{"name":"room1","service":"conference.ejabberd.local","host":"conference.ejabberd.local"}'
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.9p229
+      Content-Length:
+      - '89'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - jabber
+      Authorization:
+      - Basic YWRtaW5AZWphYmJlcmQubG9jYWw6ZGVmYXVsdHB3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '1'
+      Content-Type:
+      - application/json
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Content-Type, Authorization, X-Admin
+    body:
+      encoding: UTF-8
+      string: '0'
+  recorded_at: Thu, 20 Jan 2022 13:20:27 GMT
+- request:
+    method: post
+    uri: http://jabber/api/set_room_affiliation
+    body:
+      encoding: UTF-8
+      string: '{"name":"room1","service":"conference.ejabberd.local","jid":"tom@localhost","affiliation":"member"}'
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.9p229
+      Content-Length:
+      - '99'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - jabber
+      Authorization:
+      - Basic YWRtaW5AZWphYmJlcmQubG9jYWw6ZGVmYXVsdHB3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '1'
+      Content-Type:
+      - application/json
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Content-Type, Authorization, X-Admin
+    body:
+      encoding: UTF-8
+      string: '0'
+  recorded_at: Thu, 20 Jan 2022 13:20:27 GMT
+- request:
+    method: post
+    uri: http://jabber/api/get_room_affiliations
+    body:
+      encoding: UTF-8
+      string: '{"name":"room1","service":"conference.ejabberd.local"}'
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.9p229
+      Content-Length:
+      - '54'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - jabber
+      Authorization:
+      - Basic YWRtaW5AZWphYmJlcmQubG9jYWw6ZGVmYXVsdHB3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Content-Type, Authorization, X-Admin
+    body:
+      encoding: UTF-8
+      string: '[{"username":"tom","domain":"localhost","affiliation":"member","reason":""}]'
+  recorded_at: Thu, 20 Jan 2022 13:20:27 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/JabberAdmin_Commands_GetRoomAffiliations/when_the_room_exists/with_affiliations/behaves_like_a_command/passes_get_room_affiliations_as_command_name_to_the_callable.yml
+++ b/spec/fixtures/vcr_cassettes/JabberAdmin_Commands_GetRoomAffiliations/when_the_room_exists/with_affiliations/behaves_like_a_command/passes_get_room_affiliations_as_command_name_to_the_callable.yml
@@ -1,0 +1,75 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://jabber/api/create_room
+    body:
+      encoding: UTF-8
+      string: '{"name":"room1","service":"conference.ejabberd.local","host":"conference.ejabberd.local"}'
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.9p229
+      Content-Length:
+      - '89'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - jabber
+      Authorization:
+      - Basic YWRtaW5AZWphYmJlcmQubG9jYWw6ZGVmYXVsdHB3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '1'
+      Content-Type:
+      - application/json
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Content-Type, Authorization, X-Admin
+    body:
+      encoding: UTF-8
+      string: '0'
+  recorded_at: Thu, 20 Jan 2022 13:20:27 GMT
+- request:
+    method: post
+    uri: http://jabber/api/set_room_affiliation
+    body:
+      encoding: UTF-8
+      string: '{"name":"room1","service":"conference.ejabberd.local","jid":"tom@localhost","affiliation":"member"}'
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.9p229
+      Content-Length:
+      - '99'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - jabber
+      Authorization:
+      - Basic YWRtaW5AZWphYmJlcmQubG9jYWw6ZGVmYXVsdHB3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '1'
+      Content-Type:
+      - application/json
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Content-Type, Authorization, X-Admin
+    body:
+      encoding: UTF-8
+      string: '0'
+  recorded_at: Thu, 20 Jan 2022 13:20:27 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/JabberAdmin_Commands_GetRoomAffiliations/when_the_room_exists/with_affiliations/behaves_like_a_command/passes_the_name_symbol_to_the_callable.yml
+++ b/spec/fixtures/vcr_cassettes/JabberAdmin_Commands_GetRoomAffiliations/when_the_room_exists/with_affiliations/behaves_like_a_command/passes_the_name_symbol_to_the_callable.yml
@@ -1,0 +1,75 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://jabber/api/create_room
+    body:
+      encoding: UTF-8
+      string: '{"name":"room1","service":"conference.ejabberd.local","host":"conference.ejabberd.local"}'
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.9p229
+      Content-Length:
+      - '89'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - jabber
+      Authorization:
+      - Basic YWRtaW5AZWphYmJlcmQubG9jYWw6ZGVmYXVsdHB3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '1'
+      Content-Type:
+      - application/json
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Content-Type, Authorization, X-Admin
+    body:
+      encoding: UTF-8
+      string: '0'
+  recorded_at: Thu, 20 Jan 2022 13:20:27 GMT
+- request:
+    method: post
+    uri: http://jabber/api/set_room_affiliation
+    body:
+      encoding: UTF-8
+      string: '{"name":"room1","service":"conference.ejabberd.local","jid":"tom@localhost","affiliation":"member"}'
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.9p229
+      Content-Length:
+      - '99'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - jabber
+      Authorization:
+      - Basic YWRtaW5AZWphYmJlcmQubG9jYWw6ZGVmYXVsdHB3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '1'
+      Content-Type:
+      - application/json
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Content-Type, Authorization, X-Admin
+    body:
+      encoding: UTF-8
+      string: '0'
+  recorded_at: Thu, 20 Jan 2022 13:20:27 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/JabberAdmin_Commands_GetRoomAffiliations/when_the_room_exists/with_affiliations/behaves_like_a_command/passes_the_service_symbol_to_the_callable.yml
+++ b/spec/fixtures/vcr_cassettes/JabberAdmin_Commands_GetRoomAffiliations/when_the_room_exists/with_affiliations/behaves_like_a_command/passes_the_service_symbol_to_the_callable.yml
@@ -1,0 +1,75 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://jabber/api/create_room
+    body:
+      encoding: UTF-8
+      string: '{"name":"room1","service":"conference.ejabberd.local","host":"conference.ejabberd.local"}'
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.9p229
+      Content-Length:
+      - '89'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - jabber
+      Authorization:
+      - Basic YWRtaW5AZWphYmJlcmQubG9jYWw6ZGVmYXVsdHB3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '1'
+      Content-Type:
+      - application/json
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Content-Type, Authorization, X-Admin
+    body:
+      encoding: UTF-8
+      string: '0'
+  recorded_at: Thu, 20 Jan 2022 13:20:27 GMT
+- request:
+    method: post
+    uri: http://jabber/api/set_room_affiliation
+    body:
+      encoding: UTF-8
+      string: '{"name":"room1","service":"conference.ejabberd.local","jid":"tom@localhost","affiliation":"member"}'
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.9p229
+      Content-Length:
+      - '99'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - jabber
+      Authorization:
+      - Basic YWRtaW5AZWphYmJlcmQubG9jYWw6ZGVmYXVsdHB3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '1'
+      Content-Type:
+      - application/json
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Content-Type, Authorization, X-Admin
+    body:
+      encoding: UTF-8
+      string: '0'
+  recorded_at: Thu, 20 Jan 2022 13:20:27 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/JabberAdmin_Commands_GetRoomAffiliations/when_the_room_exists/with_affiliations/returns_the_room_affiliations.yml
+++ b/spec/fixtures/vcr_cassettes/JabberAdmin_Commands_GetRoomAffiliations/when_the_room_exists/with_affiliations/returns_the_room_affiliations.yml
@@ -1,0 +1,111 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://jabber/api/create_room
+    body:
+      encoding: UTF-8
+      string: '{"name":"room1","service":"conference.ejabberd.local","host":"conference.ejabberd.local"}'
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.9p229
+      Content-Length:
+      - '89'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - jabber
+      Authorization:
+      - Basic YWRtaW5AZWphYmJlcmQubG9jYWw6ZGVmYXVsdHB3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '1'
+      Content-Type:
+      - application/json
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Content-Type, Authorization, X-Admin
+    body:
+      encoding: UTF-8
+      string: '0'
+  recorded_at: Thu, 20 Jan 2022 13:20:27 GMT
+- request:
+    method: post
+    uri: http://jabber/api/set_room_affiliation
+    body:
+      encoding: UTF-8
+      string: '{"name":"room1","service":"conference.ejabberd.local","jid":"tom@localhost","affiliation":"member"}'
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.9p229
+      Content-Length:
+      - '99'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - jabber
+      Authorization:
+      - Basic YWRtaW5AZWphYmJlcmQubG9jYWw6ZGVmYXVsdHB3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '1'
+      Content-Type:
+      - application/json
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Content-Type, Authorization, X-Admin
+    body:
+      encoding: UTF-8
+      string: '0'
+  recorded_at: Thu, 20 Jan 2022 13:20:27 GMT
+- request:
+    method: post
+    uri: http://jabber/api/get_room_affiliations
+    body:
+      encoding: UTF-8
+      string: '{"name":"room1","service":"conference.ejabberd.local"}'
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.9p229
+      Content-Length:
+      - '54'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - jabber
+      Authorization:
+      - Basic YWRtaW5AZWphYmJlcmQubG9jYWw6ZGVmYXVsdHB3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Content-Type, Authorization, X-Admin
+    body:
+      encoding: UTF-8
+      string: '[{"username":"tom","domain":"localhost","affiliation":"member","reason":""}]'
+  recorded_at: Thu, 20 Jan 2022 13:20:27 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/JabberAdmin_Commands_GetRoomAffiliations/when_the_room_exists/without_affiliations/behaves_like_a_command/calls_the_call_method_on_the_given_callable.yml
+++ b/spec/fixtures/vcr_cassettes/JabberAdmin_Commands_GetRoomAffiliations/when_the_room_exists/without_affiliations/behaves_like_a_command/calls_the_call_method_on_the_given_callable.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://jabber/api/create_room
+    body:
+      encoding: UTF-8
+      string: '{"name":"room2","service":"conference.ejabberd.local","host":"conference.ejabberd.local"}'
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.9p229
+      Content-Length:
+      - '89'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - jabber
+      Authorization:
+      - Basic YWRtaW5AZWphYmJlcmQubG9jYWw6ZGVmYXVsdHB3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '1'
+      Content-Type:
+      - application/json
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Content-Type, Authorization, X-Admin
+    body:
+      encoding: UTF-8
+      string: '0'
+  recorded_at: Thu, 20 Jan 2022 13:20:27 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/JabberAdmin_Commands_GetRoomAffiliations/when_the_room_exists/without_affiliations/behaves_like_a_command/integration_test/raises_no_errors.yml
+++ b/spec/fixtures/vcr_cassettes/JabberAdmin_Commands_GetRoomAffiliations/when_the_room_exists/without_affiliations/behaves_like_a_command/integration_test/raises_no_errors.yml
@@ -1,0 +1,75 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://jabber/api/create_room
+    body:
+      encoding: UTF-8
+      string: '{"name":"room2","service":"conference.ejabberd.local","host":"conference.ejabberd.local"}'
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.9p229
+      Content-Length:
+      - '89'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - jabber
+      Authorization:
+      - Basic YWRtaW5AZWphYmJlcmQubG9jYWw6ZGVmYXVsdHB3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '1'
+      Content-Type:
+      - application/json
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Content-Type, Authorization, X-Admin
+    body:
+      encoding: UTF-8
+      string: '0'
+  recorded_at: Thu, 20 Jan 2022 13:20:27 GMT
+- request:
+    method: post
+    uri: http://jabber/api/get_room_affiliations
+    body:
+      encoding: UTF-8
+      string: '{"name":"room2","service":"conference.ejabberd.local"}'
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.9p229
+      Content-Length:
+      - '54'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - jabber
+      Authorization:
+      - Basic YWRtaW5AZWphYmJlcmQubG9jYWw6ZGVmYXVsdHB3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Content-Type, Authorization, X-Admin
+    body:
+      encoding: UTF-8
+      string: "[]"
+  recorded_at: Thu, 20 Jan 2022 13:20:27 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/JabberAdmin_Commands_GetRoomAffiliations/when_the_room_exists/without_affiliations/behaves_like_a_command/passes_get_room_affiliations_as_command_name_to_the_callable.yml
+++ b/spec/fixtures/vcr_cassettes/JabberAdmin_Commands_GetRoomAffiliations/when_the_room_exists/without_affiliations/behaves_like_a_command/passes_get_room_affiliations_as_command_name_to_the_callable.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://jabber/api/create_room
+    body:
+      encoding: UTF-8
+      string: '{"name":"room2","service":"conference.ejabberd.local","host":"conference.ejabberd.local"}'
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.9p229
+      Content-Length:
+      - '89'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - jabber
+      Authorization:
+      - Basic YWRtaW5AZWphYmJlcmQubG9jYWw6ZGVmYXVsdHB3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '1'
+      Content-Type:
+      - application/json
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Content-Type, Authorization, X-Admin
+    body:
+      encoding: UTF-8
+      string: '0'
+  recorded_at: Thu, 20 Jan 2022 13:20:27 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/JabberAdmin_Commands_GetRoomAffiliations/when_the_room_exists/without_affiliations/behaves_like_a_command/passes_the_name_symbol_to_the_callable.yml
+++ b/spec/fixtures/vcr_cassettes/JabberAdmin_Commands_GetRoomAffiliations/when_the_room_exists/without_affiliations/behaves_like_a_command/passes_the_name_symbol_to_the_callable.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://jabber/api/create_room
+    body:
+      encoding: UTF-8
+      string: '{"name":"room2","service":"conference.ejabberd.local","host":"conference.ejabberd.local"}'
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.9p229
+      Content-Length:
+      - '89'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - jabber
+      Authorization:
+      - Basic YWRtaW5AZWphYmJlcmQubG9jYWw6ZGVmYXVsdHB3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '1'
+      Content-Type:
+      - application/json
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Content-Type, Authorization, X-Admin
+    body:
+      encoding: UTF-8
+      string: '0'
+  recorded_at: Thu, 20 Jan 2022 13:20:27 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/JabberAdmin_Commands_GetRoomAffiliations/when_the_room_exists/without_affiliations/behaves_like_a_command/passes_the_service_symbol_to_the_callable.yml
+++ b/spec/fixtures/vcr_cassettes/JabberAdmin_Commands_GetRoomAffiliations/when_the_room_exists/without_affiliations/behaves_like_a_command/passes_the_service_symbol_to_the_callable.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://jabber/api/create_room
+    body:
+      encoding: UTF-8
+      string: '{"name":"room2","service":"conference.ejabberd.local","host":"conference.ejabberd.local"}'
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.9p229
+      Content-Length:
+      - '89'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - jabber
+      Authorization:
+      - Basic YWRtaW5AZWphYmJlcmQubG9jYWw6ZGVmYXVsdHB3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '1'
+      Content-Type:
+      - application/json
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Content-Type, Authorization, X-Admin
+    body:
+      encoding: UTF-8
+      string: '0'
+  recorded_at: Thu, 20 Jan 2022 13:20:27 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/JabberAdmin_Commands_GetRoomAffiliations/when_the_room_exists/without_affiliations/returns_empty_room_affiliations.yml
+++ b/spec/fixtures/vcr_cassettes/JabberAdmin_Commands_GetRoomAffiliations/when_the_room_exists/without_affiliations/returns_empty_room_affiliations.yml
@@ -1,0 +1,75 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://jabber/api/create_room
+    body:
+      encoding: UTF-8
+      string: '{"name":"room2","service":"conference.ejabberd.local","host":"conference.ejabberd.local"}'
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.9p229
+      Content-Length:
+      - '89'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - jabber
+      Authorization:
+      - Basic YWRtaW5AZWphYmJlcmQubG9jYWw6ZGVmYXVsdHB3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '1'
+      Content-Type:
+      - application/json
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Content-Type, Authorization, X-Admin
+    body:
+      encoding: UTF-8
+      string: '0'
+  recorded_at: Thu, 20 Jan 2022 13:20:27 GMT
+- request:
+    method: post
+    uri: http://jabber/api/get_room_affiliations
+    body:
+      encoding: UTF-8
+      string: '{"name":"room2","service":"conference.ejabberd.local"}'
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.9p229
+      Content-Length:
+      - '54'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - jabber
+      Authorization:
+      - Basic YWRtaW5AZWphYmJlcmQubG9jYWw6ZGVmYXVsdHB3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Content-Type, Authorization, X-Admin
+    body:
+      encoding: UTF-8
+      string: "[]"
+  recorded_at: Thu, 20 Jan 2022 13:20:27 GMT
+recorded_with: VCR 6.0.0

--- a/spec/jabber_admin/commands/get_room_affiliations_spec.rb
+++ b/spec/jabber_admin/commands/get_room_affiliations_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe JabberAdmin::Commands::GetRoomAffiliations do
+  let(:room) { 'room1@conference.ejabberd.local' }
+  let(:host) { room.split('@').last }
+  let(:action) { JabberAdmin.get_room_affiliations!(room: room) }
+
+  context 'when the room exists', :vcr do
+    before { JabberAdmin.create_room(room: room, host: host) }
+
+    context 'with affiliations' do
+      before do
+        JabberAdmin.set_room_affiliation(room: room, user: 'tom@localhost')
+      end
+
+      it_behaves_like 'a command',
+                      with_name: 'get_room_affiliations',
+                      with_input_args: [
+                        room: 'room1@conference.ejabberd.local'
+                      ],
+                      with_called_args: [
+                        name: 'room1',
+                        service: 'conference.ejabberd.local'
+                      ]
+
+      it 'returns the room affiliations' do
+        expect(action).to include(a_hash_including({
+                                                     'username' => 'tom',
+                                                     'domain' => 'localhost'
+                                                   }))
+      end
+    end
+
+    context 'without affiliations' do
+      let(:room) { 'room2@conference.ejabberd.local' }
+
+      it_behaves_like 'a command',
+                      with_name: 'get_room_affiliations',
+                      with_input_args: [
+                        room: 'room2@conference.ejabberd.local'
+                      ],
+                      with_called_args: [
+                        name: 'room2',
+                        service: 'conference.ejabberd.local'
+                      ]
+
+      it 'returns empty room affiliations' do
+        expect(action).to be_eql([])
+      end
+    end
+  end
+
+  context 'when the room does not exist', :vcr do
+    let(:room) { 'vroom@conference.ejabberd.local' }
+
+    it 'raises an error' do
+      expect { action }.to raise_error(JabberAdmin::CommandError)
+    end
+  end
+end

--- a/spec/jabber_admin_spec.rb
+++ b/spec/jabber_admin_spec.rb
@@ -165,6 +165,27 @@ RSpec.describe JabberAdmin do
     end
   end
 
+  describe '.room_exist?', :vcr do
+    let(:room) { 'room1@conference.ejabberd.local' }
+    let(:host) { room.split('@').last }
+
+    context 'with an existing room' do
+      before { described_class.create_room(room: room, host: host) }
+
+      it 'returns true' do
+        expect(described_class.room_exist?(room)). to eq(true)
+      end
+    end
+
+    context 'without an existing room' do
+      let(:room) { 'no-room@conference.ejabberd.local' }
+
+      it 'returns false' do
+        expect(described_class.room_exist?(room)). to eq(false)
+      end
+    end
+  end
+
   describe '.respond_to?' do
     context 'with predefined commands' do
       it 'responds to commands with bang' do


### PR DESCRIPTION
Additionally a top-level helper method `JabberAdmin.room_exist?` has been added.

This uses the new `get_room_affiliations` command and determines room existance by checking the command result. If the room exists, it will always return an array (possibly empty), if it doesn't, it returns error 400 with the message "The room does not exist."